### PR TITLE
🐞 Fix nested measured() blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "rm -vfR lib && babel --only '**/index.js' --no-comments --compact true --minified --source-maps false --out-dir lib src; cp -vfR package.json package-lock.json yarn.lock README.md LICENSE.md lib/",
     "documentation": "rm -fR docs; (cd src; find . -type f -name index.js | xargs jsdoc --destination ../docs --package ../package.json --readme ../README.md)",
     "lint": "eslint src",
-    "test": "nyc --silent --check-coverage --lines 100 --per-file mocha --require @babel/register src/spec.setup.js src/**/spec.js"
+    "test": "nyc --silent --check-coverage --lines 100 --branches 100 --functions 100 --statements 100 --per-file --include '**/index.js' mocha --require @babel/register src/spec.setup.js src/**/spec.js"
   },
   "devDependencies": {
     "@babel/cli": "7.6.0",

--- a/src/spec.js
+++ b/src/spec.js
@@ -5,6 +5,41 @@ import { fake } from 'sinon';
 import measured from '.';
 
 describe('#measured()', () => {
+  describe('when given an id', () => {
+    it('includes that id in its measurement', async () => {
+      const onComplete = fake();
+      const behavior = fake();
+      await measured(behavior, { id: 'CrabSalad', onComplete });
+      expect(onComplete.getCall(0).args[0]).to.have.property('id', 'CrabSalad');
+    });
+  });
+
+  describe('when nested within another measured block', () => {
+    it('invokes the onComplete callback of the outer block', async () => {
+      const inner = fake();
+      const outer = fake();
+      const behavior = fake();
+
+      await measured(async () => {
+        await measured(behavior, { onComplete: inner });
+      }, { onComplete: outer });
+
+      expect(outer).to.have.been.calledOnce;
+    });
+
+    it('invokes the onComplete callback of the inner block', async () => {
+      const inner = fake();
+      const outer = fake();
+      const behavior = fake();
+
+      await measured(async () => {
+        await measured(behavior, { onComplete: inner });
+      }, { onComplete: outer });
+
+      expect(inner).to.have.been.calledOnce;
+    });
+  });
+
   it('resolves to the wrapped resolution', () => {
     const result = 'the wrapped resolution';
     const behavior = fake.returns(result);


### PR DESCRIPTION
If one `measured()` block is nested within another, then only
the outer block's callbacks would be invoked. This was happening
because the outer block's performance observer is notified of the
inner block's "mark" performance entry, but there was no validation
of whether the performance entry matches the one this particular
observer is expecting. **Any** performance entry of type "mark"
would have triggered all pending `measured()` blocks to complete,
in the order in which they were created.

This commit addresses this by validating the name of the performance
entry against the expected id for which that `measured()` block is
listening.

Additional test coverage has been added for this case.
The test script has now been modified to enforce strict 100% coverage
not only for lines, but also for functions, statements, and branches.
An additional test has been added to cover the optional `id` option,
which allows the caller to override the identifier used for peformance
entries.